### PR TITLE
Improve callback signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,50 +127,15 @@ synthesizers or filter-like audio effects.
 
     """Loop back five seconds of audio data."""
 
-    def callback(in_data, frame_count, time_info, status):
-        return (in_data, continue_flag)
+    def callback(in_data, out_data, time_info, status):
+        out_data[:] = in_data
+        return continue_flag
 
     s = Stream(sample_rate=44100, block_length=16, callback=callback)
     s.start()
     time.sleep(5)
     s.stop()
 ```
-
-However, callback mode is somewhat burdensome for playing back audio
-data from a file. Note how the callback now has to split up the audio
-data into blocks and stop the stream when there is no more data
-available.
-
-```python
-    import sys
-    import time
-    import numpy as np
-    from scipy.io.wavfile import read as wavread
-    from pysoundcard import Stream, continue_flag, complete_flag
-
-    """Play an audio file."""
-
-    fs, wave = wavread(sys.argv[1])
-    wave = np.array(wave, dtype=np.float32)
-    wave /= 2**15 # normalize -max_int16..max_int16 to -1..1
-    play_position = 0
-
-    def callback(in_data, frame_count, time_info, status):
-        global play_position
-        out_data = wave[play_position:play_position+block_length]
-        play_position += block_length
-        if play_position+block_length < len(wave):
-            return (out_data, continue_flag)
-        else:
-            return (out_data, complete_flag)
-
-    block_length = 16
-    s = Stream(sample_rate=fs, block_length=block_length, callback=callback)
-    s.start()
-    while s.is_active():
-        time.sleep(0.1)
-```
-
 
 ### When to use Read/Write Mode or Callback Mode
 
@@ -201,8 +166,9 @@ context manager that makes things more convenient in simple cases:
 
     """Loop back five seconds of audio data."""
 
-    def callback(in_data, frame_count, time_info, status):
-        return (in_data, continue_flag)
+    def callback(in_data, out_data, time_info, status):
+        out_data[:] = in_data
+        return continue_flag
 
     with Stream(sample_rate=44100, block_length=16, callback=callback):
         time.sleep(5)

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -331,21 +331,22 @@ class Stream(object):
 
         The callback should have a signature like this:
 
-        callback(input_data, num_frames, time_info, status_flags)
+        callback(input, output, time, status) -> flag
 
-        where input_data is the recorded data as a numpy array,
-        num_frames is the provided/requested number of frames,
-        time_info is a dictionary with some timing information, and
-        status_flags indicates whether input or output buffers have
+        where input is the recorded data as a NumPy array, output is
+        another NumPy array (with uninitialized content), where the data
+        for playback has to be written to (using indexing).
+        Either input or output can be None if the stream was started
+        without input or output device, respectively.
+        time is a dictionary with some timing information, and
+        status indicates whether input or output buffers have
         been inserted or dropped to overcome underflow or overflow
         conditions.
 
-        The function must return a tuple (output_data, flag), where
-        flag is one of continue_flag, complete_flag or abort_flag.
-        complete_flag and abort_flag act as if stop() or abort() had
-        been called. continue_flag resumes normal audio processing.
-        The output_data must be a numpy array with the appropriate
-        number of frames.
+        The function must return one of continue_flag, complete_flag or
+        abort_flag.  complete_flag and abort_flag act as if stop() or
+        abort() had been called, respectively.  continue_flag resumes
+        normal audio processing.
 
         The finished_callback should be a function with no arguments
         and no return values.

--- a/tests/context_manager.py
+++ b/tests/context_manager.py
@@ -3,8 +3,9 @@ import time
 
 """Loop back five seconds of audio data."""
 
-def callback(in_data, frame_count, time_info, status):
-    return (in_data, continue_flag)
+def callback(in_data, out_data, time_info, status):
+    out_data[:] = in_data
+    return continue_flag
 
 with Stream(sample_rate=44100, block_length=16, callback=callback):
     time.sleep(5)

--- a/tests/loopback_callback.py
+++ b/tests/loopback_callback.py
@@ -3,8 +3,9 @@ import time
 
 """Loop back five seconds of audio data."""
 
-def callback(in_data, frame_count, time_info, status):
-    return (in_data, continue_flag)
+def callback(in_data, out_data, time_info, status):
+    out_data[:] = in_data
+    return continue_flag
 
 s = Stream(sample_rate=44100, block_length=16, callback=callback)
 s.start()

--- a/tests/playback_callback.py
+++ b/tests/playback_callback.py
@@ -11,14 +11,15 @@ wave = np.array(wave, dtype=np.float32)
 wave /= 2**15 # normalize -max_int16..max_int16 to -1..1
 play_position = 0
 
-def callback(in_data, frame_count, time_info, status):
+def callback(in_data, out_data, time_info, status):
     global play_position
-    out_data = wave[play_position:play_position+block_length]
+    out_data[:] = wave[play_position:play_position+block_length]
+    # TODO: handle last (often incomplete) block
     play_position += block_length
     if play_position+block_length < len(wave):
-        return (out_data, continue_flag)
+        return continue_flag
     else:
-        return (out_data, complete_flag)
+        return complete_flag
 
 block_length = 16
 s = Stream(sample_rate=fs, block_length=block_length, callback=callback)


### PR DESCRIPTION
This would reduce the amount of copying data and, more importantly, allocating memory (which should be avoided).

This doesn't make a lot of difference in the example programs in `tests/`, because _views_ can be returned in the callback.
But in the more general case (especially if `block_length=0`), memory has to be reserved and an additional copy has to be made.
PortAudio already reserves memory for the buffers, so this should be available directly to the user.

The downside is, that the user now has to use indexing to fill the output array, e.g.:

```
output[:] = ...
```

If desired, I can also add this change to the examples and the documentation.
