### PR TITLE
Add OutputStream and InputStream classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ from pysoundcard import Stream
 """Loop back five seconds of audio data."""
 
 fs = 44100
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
-for n in range(int(fs*5/block_length)):
-    s.write(s.read(block_length))
+for n in range(int(fs*5/blocksize)):
+    s.write(s.read(blocksize))
 s.stop()
 ```
 
@@ -100,8 +100,8 @@ fs, wave = wavread(sys.argv[1])
 wave = np.array(wave, dtype=np.float32)
 wave /= 2**15 # normalize -max_int16..max_int16 to -1..1
 
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
 s.write(wave)
 s.stop()
@@ -130,7 +130,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-s = Stream(sample_rate=44100, block_length=16, callback=callback)
+s = Stream(samplerate=44100, blocksize=16, callback=callback)
 s.start()
 time.sleep(5)
 s.stop()
@@ -181,7 +181,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-with Stream(sample_rate=44100, block_length=16, callback=callback):
+with Stream(samplerate=44100, blocksize=16, callback=callback):
     time.sleep(5)
 ```
 

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -225,7 +225,7 @@ def hostapi_info(index=None):
         return (hostapi_info(i) for i in range(_pa.Pa_GetHostApiCount()))
     else:
         info = _pa.Pa_GetHostApiInfo(index)
-        if info == ffi.NULL:
+        if not info:
             raise RuntimeError("Invalid host API")
         assert info.structVersion == 1
         return {'name': ffi.string(info.name).decode(errors='ignore'),
@@ -242,7 +242,7 @@ def device_info(index=None):
         return (device_info(i) for i in range(_pa.Pa_GetDeviceCount()))
     else:
         info = _pa.Pa_GetDeviceInfo(index)
-        if info == ffi.NULL:
+        if not info:
             raise RuntimeError("Invalid device")
         assert info.structVersion == 2
 
@@ -331,7 +331,7 @@ class _StreamBase(object):
 
         # set some stream information
         info = _pa.Pa_GetStreamInfo(self._stream)
-        if info == ffi.NULL:
+        if not info:
             raise RuntimeError("Could not obtain stream info!")
         self._input_latency = info.inputLatency
         self._output_latency = info.outputLatency

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -669,7 +669,7 @@ class Stream(_StreamBase, _Reader, _Writer):
 
         if callback:
 
-            @ffi.callback("PaStreamCallback")
+            @ffi.callback("PaStreamCallback", error=abort_flag)
             def callback_stub(input_ptr, output_ptr, frames, time, status, _):
                 input = _get_buffer(input_ptr, frames, self._input_channels,
                                     self._input_dtype)
@@ -703,7 +703,7 @@ class InputStream(_StreamBase, _Reader):
 
         if callback:
 
-            @ffi.callback("PaStreamCallback")
+            @ffi.callback("PaStreamCallback", error=abort_flag)
             def callback_stub(input_ptr, output_ptr, frames, time, status, _):
                 data = _get_buffer(input_ptr, frames, self._input_channels,
                                    self._input_dtype)
@@ -731,7 +731,7 @@ class OutputStream(_StreamBase, _Writer):
 
         if callback:
 
-            @ffi.callback("PaStreamCallback")
+            @ffi.callback("PaStreamCallback", error=abort_flag)
             def callback_stub(input_ptr, output_ptr, frames, time, status, _):
                 data = _get_buffer(output_ptr, frames, self._output_channels,
                                    self._output_dtype)

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -553,8 +553,10 @@ def _setup_stream_parameters(kind, device, channels, dtype, latency,
     info = device_info(device)
     if channels is None:
         channels = info['max_' + kind + '_channels']
-    if latency is None:
+    if latency in (None, 'low'):
         latency = info['default_low_' + kind + '_latency']
+    elif latency == 'high':
+        latency = info['default_high_' + kind + '_latency']
     dtype = np.dtype(dtype)
     try:
         sample_format = _np2pa[dtype]

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -294,18 +294,21 @@ class _StreamBase(object):
     """Base class for Stream, InputStream and OutputStream."""
 
     def __init__(self, stream_parameters_in, stream_parameters_out,
-                 samplerate, blocksize, finished_callback, **flags):
+                 samplerate, blocksize, finished_callback,
+                 clip_off=False, dither_off=False,
+                 never_drop_input=False,
+                 prime_output_buffers_using_stream_callback=False):
         if blocksize is None:
             blocksize = init.blocksize
 
         stream_flags = 0x0
-        if 'no_clipping' in flags:
+        if clip_off:
             stream_flags |= 0x00000001
-        if 'no_dithering' in flags:
+        if dither_off:
             stream_flags |= 0x00000002
-        if 'never_drop_input' in flags and flags['never_drop_input']:
+        if never_drop_input:
             stream_flags |= 0x00000004
-        if 'prime_output_buffers_using_callback' in flags:
+        if prime_output_buffers_using_stream_callback:
             stream_flags |= 0x00000008
 
         self._stream = ffi.new("PaStream**")

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -313,13 +313,11 @@ class Stream(object):
 
     """
 
-    def __init__(self, samplerate=44100, blocksize=0,
+    def __init__(self, samplerate=None, blocksize=0,
                  input_device=True, output_device=True,
                  callback=None, finished_callback=None,
                  **flags):
         """Open a new stream.
-
-        If no sample rate is given, 44100 Hz is assumed.
 
         If no input or output device (or True) is specified, the
         default input/output device is taken. For input/output-only

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -451,8 +451,8 @@ class Stream(object):
         info = _pa.Pa_GetStreamInfo(self._stream)
         if info == ffi.NULL:
             raise RuntimeError("Could not obtain stream info!")
-        self.input_latency = info.inputLatency,
-        self.output_latency = info.outputLatency,
+        self.input_latency = info.inputLatency
+        self.output_latency = info.outputLatency
 
         if finished_callback:
             @ffi.callback("PaStreamFinishedCallback")

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -245,7 +245,7 @@ def _dev2dict(dev, index):
             'default_low_output_latency': dev.defaultLowOutputLatency,
             'default_high_input_latency': dev.defaultHighInputLatency,
             'default_high_output_latency': dev.defaultHighOutputLatency,
-            'default_sample_rate': dev.defaultSampleRate,
+            'default_samplerate': dev.defaultSampleRate,
             'input_latency': dev.defaultLowInputLatency,
             'output_latency': dev.defaultLowOutputLatency,
             'sample_format': np.float32,
@@ -313,7 +313,7 @@ class Stream(object):
 
     """
 
-    def __init__(self, sample_rate=44100, block_length=0,
+    def __init__(self, samplerate=44100, blocksize=0,
                  input_device=True, output_device=True,
                  callback=None, finished_callback=None,
                  **flags):
@@ -439,8 +439,8 @@ class Stream(object):
 
         self._stream = ffi.new("PaStream**")
         err = _pa.Pa_OpenStream(self._stream, stream_parameters_in or ffi.NULL,
-                                stream_parameters_out or ffi.NULL, sample_rate,
-                                block_length, stream_flags, self._callback,
+                                stream_parameters_out or ffi.NULL, samplerate,
+                                blocksize, stream_flags, self._callback,
                                 ffi.NULL)
         self._handle_error(err)
 
@@ -448,8 +448,8 @@ class Stream(object):
         self._stream = self._stream[0]
 
         # set some stream information
-        self.sample_rate = sample_rate
-        self.block_length = block_length
+        self.samplerate = samplerate
+        self.blocksize = blocksize
         info = _pa.Pa_GetStreamInfo(self._stream)
         if info == ffi.NULL:
             raise RuntimeError("Could not obtain stream info!")
@@ -618,9 +618,9 @@ class Stream(object):
     def write(self, data):
         """Write samples to an output stream.
 
-        As much as one block_length of audio data will be played
-        without blocking. If more than one block_length was provided,
-        the function will only return when all but one block_length
+        As much as one blocksize of audio data will be played
+        without blocking. If more than one blocksize was provided,
+        the function will only return when all but one blocksize
         has been played.
 
         Data will be converted to a numpy matrix. Multichannel data
@@ -665,17 +665,17 @@ if __name__ == '__main__':
     fs, wave = wavread('thistle.wav')
     wave = np.array(wave, dtype=np.float32)
     wave /= 2**15
-    block_length = 4
+    blocksize = 4
 
     def callback(in_data, frame_count, time_info, status):
         if status != 0:
             print(status)
         return (in_data, continue_flag)
-    s = Stream(sample_rate=fs, block_length=block_length, callback=callback)
+    s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
     s.start()
-    # for n in range(int(fs*5/block_length)):
-    #     s.write(s.read(block_length))
-    # for idx in range(0, wave.size, block_length):
-    #     s.write(wave[idx:idx+block_length])
+    # for n in range(int(fs*5/blocksize)):
+    #     s.write(s.read(blocksize))
+    # for idx in range(0, wave.size, blocksize):
+    #     s.write(wave[idx:idx+blocksize])
     time.sleep(5)
     s.stop()

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -655,25 +655,3 @@ class Stream(object):
         data = data.ravel().tostring()
         err = _pa.Pa_WriteStream(self._stream, data, frames)
         self._handle_error(err)
-
-
-if __name__ == '__main__':
-    from scipy.io.wavfile import read as wavread
-    import time
-    fs, wave = wavread('thistle.wav')
-    wave = np.array(wave, dtype=np.float32)
-    wave /= 2**15
-    blocksize = 4
-
-    def callback(in_data, frame_count, time_info, status):
-        if status != 0:
-            print(status)
-        return (in_data, continue_flag)
-    s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
-    s.start()
-    # for n in range(int(fs*5/blocksize)):
-    #     s.write(s.read(blocksize))
-    # for idx in range(0, wave.size, blocksize):
-    #     s.write(wave[idx:idx+blocksize])
-    time.sleep(5)
-    s.stop()

--- a/tests/context_manager.py
+++ b/tests/context_manager.py
@@ -7,5 +7,5 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-with Stream(sample_rate=44100, block_length=16, callback=callback):
+with Stream(samplerate=44100, blocksize=16, callback=callback):
     time.sleep(5)

--- a/tests/loopback_blocking.py
+++ b/tests/loopback_blocking.py
@@ -3,9 +3,9 @@ from pysoundcard import Stream
 """Loop back five seconds of audio data."""
 
 fs = 44100
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
-for n in range(int(fs * 5 / block_length)):
-    s.write(s.read(block_length))
+for n in range(int(fs * 5 / blocksize)):
+    s.write(s.read(blocksize))
 s.stop()

--- a/tests/loopback_callback.py
+++ b/tests/loopback_callback.py
@@ -7,7 +7,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-s = Stream(sample_rate=44100, block_length=16, callback=callback)
+s = Stream(samplerate=44100, blocksize=16, callback=callback)
 s.start()
 time.sleep(5)
 s.stop()

--- a/tests/playback_blocking.py
+++ b/tests/playback_blocking.py
@@ -9,8 +9,8 @@ fs, wave = wavread(sys.argv[1])
 wave = np.array(wave, dtype=np.float32)
 wave /= 2 ** 15  # normalize -max_int16..max_int16 to -1..1
 
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
 s.write(wave)
 s.stop()

--- a/tests/playback_callback.py
+++ b/tests/playback_callback.py
@@ -11,18 +11,8 @@ wave = np.array(wave, dtype=np.float32)
 wave /= 2 ** 15  # normalize -max_int16..max_int16 to -1..1
 play_position = 0
 
-def callback(in_data, out_data, time_info, status):
-    global play_position
-    out_data[:] = wave[play_position:play_position + block_length]
-    # TODO: handle last (often incomplete) block
-    play_position += block_length
-    if play_position + block_length < len(wave):
-        return continue_flag
-    else:
-        return complete_flag
-
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length, callback=callback)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
 s.start()
 while s.is_active():
     time.sleep(0.1)


### PR DESCRIPTION
I didn't like the 3 choices for `input_device` and `output_device` in the `Stream` constructor.
The possible values are `True` (for default device), `False`-ish (for disabling the device) and a device dict to specify a certain non-default device (or other non-default settings).
I think that's quite un-symmetrical and hard for users to remember.

My suggestion is to have a `Stream` class which always has inputs *and* outputs, so it is not necessary (and not possible) to disable one of them.
For the cases where only one "direction" is needed, I implemented the classes `InputStream` and `OutputStream`.
I think from a user's perspective this is clearer and easier to use, the implementation of the 3 classes is of course a little more complicated than the 1 class. I'm not very experienced with creating class hierarchies in Python, therefore it's quite likely that my implementation can be significantly improved.

I also replaced the device dicts with device numbers and created additional arguments instead.
Now there are more constructor arguments than before, but to simplify those, I added an `init` object to the module namespace which can be used to select default settings which will be used on subsequent calls to the constructors.