### PR TITLE
Add InputStream and OutputStream classes and default object

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ from pysoundcard import Stream
 """Loop back five seconds of audio data."""
 
 fs = 44100
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
-for n in range(int(fs*5/block_length)):
-    s.write(s.read(block_length))
+for n in range(int(fs*5/blocksize)):
+    s.write(s.read(blocksize))
 s.stop()
 ```
 
@@ -100,8 +100,8 @@ fs, wave = wavread(sys.argv[1])
 wave = np.array(wave, dtype=np.float32)
 wave /= 2**15 # normalize -max_int16..max_int16 to -1..1
 
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
 s.write(wave)
 s.stop()
@@ -130,7 +130,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-s = Stream(sample_rate=44100, block_length=16, callback=callback)
+s = Stream(samplerate=44100, blocksize=16, callback=callback)
 s.start()
 time.sleep(5)
 s.stop()
@@ -181,7 +181,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-with Stream(sample_rate=44100, block_length=16, callback=callback):
+with Stream(samplerate=44100, blocksize=16, callback=callback):
     time.sleep(5)
 ```
 

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -713,13 +713,23 @@ def _time2dict(time):
 def _split(value):
     """Split input/output value into two values."""
     if isinstance(value, str):
-        # str is iterable, which would interfere with tuple unpacking
+        # iterable, but not meant for splitting
         return value, value
     try:
-        invalue, outvalue = value
-    except (TypeError, ValueError):
-        invalue = outvalue = value
-    return invalue, outvalue
+        it = iter(value)
+    except TypeError:
+        return value, value
+    try:
+        invalue = next(it)
+        outvalue = next(it)
+    except StopIteration:
+        raise ValueError("Iterables must have exactly two items")
+    try:
+        next(it)
+    except StopIteration:
+        return invalue, outvalue
+    else:
+        raise ValueError("Iterables must have exactly two items")
 
 
 def _unique(ivalue, ovalue):

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -328,7 +328,7 @@ class _StreamBase(object):
         elif not iparameters:
             self.latency = info.outputLatency
         else:
-            self.latency = _unique(info.inputLatency, info.outputLatency)
+            self.latency = info.inputLatency, info.outputLatency
 
         if finished_callback:
 
@@ -645,11 +645,11 @@ class Stream(InputStream, OutputStream):
             'input', idevice, ichannels, idtype, ilatency, samplerate)
         oparameters, odtype, osamplerate = _get_stream_parameters(
             'output', odevice, ochannels, odtype, olatency, samplerate)
-        self.dtype = _unique(idtype, odtype)
-        self.device = _unique(iparameters.device, oparameters.device)
+        self.dtype = idtype, odtype
+        self.device = iparameters.device, oparameters.device
         ichannels = iparameters.channelCount
         ochannels = oparameters.channelCount
-        self.channels = _unique(ichannels, ochannels)
+        self.channels = ichannels, ochannels
         if isamplerate != osamplerate:
             raise RuntimeError(
                 "Input and output device must have the same samplerate")
@@ -722,11 +722,6 @@ def _split(value):
     except ValueError:
         raise ValueError("Only single values and pairs are allowed")
     return invalue, outvalue
-
-
-def _unique(ivalue, ovalue):
-    """Return a single value if values are the same, a tuple if not."""
-    return ivalue if ivalue == ovalue else (ivalue, ovalue)
 
 
 class _InputOutputPair(object):

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -716,20 +716,12 @@ def _split(value):
         # iterable, but not meant for splitting
         return value, value
     try:
-        it = iter(value)
+        invalue, outvalue = value
     except TypeError:
-        return value, value
-    try:
-        invalue = next(it)
-        outvalue = next(it)
-    except StopIteration:
-        raise ValueError("Iterables must have exactly two items")
-    try:
-        next(it)
-    except StopIteration:
-        return invalue, outvalue
-    else:
-        raise ValueError("Iterables must have exactly two items")
+        invalue = outvalue = value
+    except ValueError:
+        raise ValueError("Only single values and pairs are allowed")
+    return invalue, outvalue
 
 
 def _unique(ivalue, ovalue):

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -463,12 +463,28 @@ class _StreamBase(object):
         return _pa.Pa_GetStreamCpuLoad(self._stream)
 
 
-class _Reader(object):
+class InputStream(_StreamBase):
 
-    """Mixin for read() and read_length()."""
+    """Stream for recording only.  See :class:`Stream`."""
+
+    def __init__(self, samplerate=None, blocksize=None,
+                 device=None, channels=None, dtype=None, latency=None,
+                 callback=None, finished_callback=None, **flags):
+        parameters, self.dtype, samplerate = _get_stream_parameters(
+            'input', device, channels, dtype, latency, samplerate)
+        self.device = parameters.device
+        self.channels = parameters.channelCount
+
+        def callback_wrapper(iptr, optr, frames, time, status, _):
+            data = _frombuffer(iptr, frames, self.channels, self.dtype)
+            return callback(data, _time2dict(time), status)
+
+        _StreamBase.__init__(self, parameters, ffi.NULL, samplerate,
+                             blocksize, callback and callback_wrapper,
+                             finished_callback, **flags)
 
     def read_length(self):
-        """The number of frames that can be written without waiting."""
+        """The number of frames that can be read without waiting."""
         return _pa.Pa_GetStreamReadAvailable(self._stream)
 
     def read(self, frames, raw=False):
@@ -493,12 +509,28 @@ class _Reader(object):
         return data
 
 
-class _Writer(object):
+class OutputStream(_StreamBase):
 
-    """Mixin for write() and write_length():"""
+    """Stream for playback only.  See :class:`Stream`."""
+
+    def __init__(self, samplerate=None, blocksize=None,
+                 device=None, channels=None, dtype=None, latency=None,
+                 callback=None, finished_callback=None, **flags):
+        parameters, self.dtype, samplerate = _get_stream_parameters(
+            'output', device, channels, dtype, latency, samplerate)
+        self.device = parameters.device
+        self.channels = parameters.channelCount
+
+        def callback_wrapper(iptr, optr, frames, time, status, _):
+            data = _frombuffer(optr, frames, self.channels, self.dtype)
+            return callback(data, _time2dict(time), status)
+
+        _StreamBase.__init__(self, ffi.NULL, parameters, samplerate,
+                             blocksize, callback and callback_wrapper,
+                             finished_callback, **flags)
 
     def write_length(self):
-        """The number of frames that can be read without waiting."""
+        """The number of frames that can be written without waiting."""
         return _pa.Pa_GetStreamWriteAvailable(self._stream)
 
     def write(self, data):
@@ -544,7 +576,7 @@ class _Writer(object):
         self._handle_error(err)
 
 
-class Stream(_StreamBase, _Reader, _Writer):
+class Stream(InputStream, OutputStream):
 
     """Streams handle audio input and output to your application.
 
@@ -630,42 +662,6 @@ class Stream(_StreamBase, _Reader, _Writer):
             return callback(idata, odata, _time2dict(time), status)
 
         _StreamBase.__init__(self, iparameters, oparameters, samplerate,
-                             blocksize, callback and callback_wrapper,
-                             finished_callback, **flags)
-
-
-class InputStream(_StreamBase, _Reader):
-    def __init__(self, samplerate=None, blocksize=None,
-                 device=None, channels=None, dtype=None, latency=None,
-                 callback=None, finished_callback=None, **flags):
-        parameters, self.dtype, samplerate = _get_stream_parameters(
-            'input', device, channels, dtype, latency, samplerate)
-        self.device = parameters.device
-        self.channels = parameters.channelCount
-
-        def callback_wrapper(iptr, optr, frames, time, status, _):
-            data = _frombuffer(iptr, frames, self.channels, self.dtype)
-            return callback(data, _time2dict(time), status)
-
-        _StreamBase.__init__(self, parameters, ffi.NULL, samplerate,
-                             blocksize, callback and callback_wrapper,
-                             finished_callback, **flags)
-
-
-class OutputStream(_StreamBase, _Writer):
-    def __init__(self, samplerate=None, blocksize=None,
-                 device=None, channels=None, dtype=None, latency=None,
-                 callback=None, finished_callback=None, **flags):
-        parameters, self.dtype, samplerate = _get_stream_parameters(
-            'output', device, channels, dtype, latency, samplerate)
-        self.device = parameters.device
-        self.channels = parameters.channelCount
-
-        def callback_wrapper(iptr, optr, frames, time, status, _):
-            data = _frombuffer(optr, frames, self.channels, self.dtype)
-            return callback(data, _time2dict(time), status)
-
-        _StreamBase.__init__(self, ffi.NULL, parameters, samplerate,
                              blocksize, callback and callback_wrapper,
                              finished_callback, **flags)
 

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -313,13 +313,11 @@ class Stream(object):
 
     """
 
-    def __init__(self, samplerate=44100, blocksize=0,
+    def __init__(self, samplerate=None, blocksize=0,
                  input_device=True, output_device=True,
                  callback=None, finished_callback=None,
                  **flags):
         """Open a new stream.
-
-        If no sample rate is given, 44100 Hz is assumed.
 
         If no input or output device (or True) is specified, the
         default input/output device is taken. For input/output-only

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -204,11 +204,11 @@ complete_flag = 1
 abort_flag = 2
 
 _np2pa = {
-    np.float32: 0x01,
-    np.int32:   0x02,
-    np.int16:   0x08,
-    np.int8:    0x10,
-    np.uint8:   0x20
+    np.dtype('float32'): 0x01,
+    np.dtype('int32'):   0x02,
+    np.dtype('int16'):   0x08,
+    np.dtype('int8'):    0x10,
+    np.dtype('uint8'):   0x20
 }
 
 _pa = ffi.dlopen('portaudio')
@@ -216,70 +216,55 @@ _pa.Pa_Initialize()
 atexit.register(_pa.Pa_Terminate)
 
 
-def _api2dict(api, index):
-    if api == ffi.NULL:
-        raise RuntimeError("Invalid host API info!")
-    return {'struct_version': api.structVersion,
-            'type': api.type,
-            'name': ffi.string(api.name).decode(errors='ignore'),
-            'api_idx': index,
-            'device_count': api.deviceCount,
-            'default_input_device_index': api.defaultInputDevice,
-            'default_output_device_index': api.defaultOutputDevice}
+def hostapi_info(index=None):
+    """Return a generator with information about each host API.
 
+    If index is given, only one dictionary for the given host API is
+    returned.
 
-def _dev2dict(dev, index):
-    if dev == ffi.NULL:
-        raise RuntimeError("Invalid device info!")
-    if 'DirectSound' in list(apis())[dev.hostApi]['name']:
-        enc = 'mbcs'
+    """
+    if index is None:
+        return (hostapi_info(i) for i in range(_pa.Pa_GetHostApiCount()))
     else:
-        enc = 'utf-8'
-    return {'struct_version': dev.structVersion,
-            'name': ffi.string(dev.name).decode(encoding=enc, errors='ignore'),
-            'device_index': index,
-            'host_api_index': dev.hostApi,
-            'input_channels': dev.maxInputChannels,
-            'output_channels': dev.maxOutputChannels,
-            'default_low_input_latency': dev.defaultLowInputLatency,
-            'default_low_output_latency': dev.defaultLowOutputLatency,
-            'default_high_input_latency': dev.defaultHighInputLatency,
-            'default_high_output_latency': dev.defaultHighOutputLatency,
-            'default_samplerate': dev.defaultSampleRate,
-            'input_latency': dev.defaultLowInputLatency,
-            'output_latency': dev.defaultLowOutputLatency,
-            'sample_format': np.float32,
-            'interleaved_data': True}
+        info = _pa.Pa_GetHostApiInfo(index)
+        if not info:
+            raise RuntimeError("Invalid host API")
+        assert info.structVersion == 1
+        return {'name': ffi.string(info.name).decode(errors='ignore'),
+                'default_input_device': info.defaultInputDevice,
+                'default_output_device': info.defaultOutputDevice}
 
 
-def apis():
-    """Returns a list of all available audio apis."""
-    for idx in range(_pa.Pa_GetHostApiCount()):
-        yield _api2dict(_pa.Pa_GetHostApiInfo(idx), idx)
+def device_info(index=None):
+    """Return a generator with information about each device.
 
+    If index is given, only one dictionary for the given device is
+    returned.
 
-def devices():
-    """Returns a list of all available audio devices."""
-    for idx in range(_pa.Pa_GetDeviceCount()):
-        yield _dev2dict(_pa.Pa_GetDeviceInfo(idx), idx)
+    """
+    if index is None:
+        return (device_info(i) for i in range(_pa.Pa_GetDeviceCount()))
+    else:
+        info = _pa.Pa_GetDeviceInfo(index)
+        if not info:
+            raise RuntimeError("Invalid device")
+        assert info.structVersion == 2
 
+        if 'DirectSound' in hostapi_info(info.hostApi)['name']:
+            enc = 'mbcs'
+        else:
+            enc = 'utf-8'
 
-def default_api():
-    """Returns data about the default audio api."""
-    idx = _pa.Pa_GetDefaultHostApi()
-    return _api2dict(_pa.Pa_GetHostApiInfo(idx), idx)
-
-
-def default_input_device():
-    """Returns data about the default audio input device."""
-    idx = _pa.Pa_GetDefaultInputDevice()
-    return _dev2dict(_pa.Pa_GetDeviceInfo(idx), idx)
-
-
-def default_output_device():
-    """Returns data about the default audio output device."""
-    idx = _pa.Pa_GetDefaultOutputDevice()
-    return _dev2dict(_pa.Pa_GetDeviceInfo(idx), idx)
+        return {'name': ffi.string(info.name).decode(encoding=enc,
+                                                     errors='ignore'),
+                'hostapi': info.hostApi,
+                'max_input_channels': info.maxInputChannels,
+                'max_output_channels': info.maxOutputChannels,
+                'default_low_input_latency': info.defaultLowInputLatency,
+                'default_low_output_latency': info.defaultLowOutputLatency,
+                'default_high_input_latency': info.defaultHighInputLatency,
+                'default_high_output_latency': info.defaultHighOutputLatency,
+                'default_samplerate': info.defaultSampleRate}
 
 
 def pa_version():
@@ -287,178 +272,71 @@ def pa_version():
     return (_pa.Pa_GetVersion(), ffi.string(_pa.Pa_GetVersionText()).decode())
 
 
-class Stream(object):
+class _StreamBase(object):
 
-    """Streams handle audio input and output to your application.
+    """Base class for Stream, InputStream and OutputStream."""
 
-    Each stream operates at a specific sample rate with specific
-    sample formats and buffer sizes. Each stream can either be half
-    duplex (input only or output only) or full duplex (both input and
-    output). For full duplex operation, the input and output device
-    must use the same audio api.
+    def __init__(self, iparameters, oparameters, samplerate, blocksize,
+                 callback_wrapper, finished_callback,
+                 clip_off=None, dither_off=None, never_drop_input=None,
+                 prime_output_buffers_using_stream_callback=None):
+        if blocksize is None:
+            blocksize = default.blocksize
+        if clip_off is None:
+            clip_off = default.clip_off
+        if dither_off is None:
+            dither_off = default.dither_off
+        if never_drop_input is None:
+            never_drop_input = default.never_drop_input
+        if prime_output_buffers_using_stream_callback is None:
+            prime_output_buffers_using_stream_callback = \
+                default.prime_output_buffers_using_stream_callback
 
-    Once a stream has been created, audio processing can be started
-    and stopped multiple times using start(), stop() and abort(). The
-    functions is_active() and is_stopped() can be used to check this.
-
-    The functions info(), time() and cpu_load() can be used to get
-    additional information about the stream.
-
-    Data can be read and written to the stream using read() and
-    write(). Use read_length() and write_length() to see how many
-    frames can be read or written at the current time.
-
-    Alternatively, a callback can be specified which is called
-    whenever there is data available to read or write.
-
-    """
-
-    def __init__(self, samplerate=None, blocksize=0,
-                 input_device=True, output_device=True,
-                 callback=None, finished_callback=None,
-                 **flags):
-        """Open a new stream.
-
-        If no input or output device (or True) is specified, the
-        default input/output device is taken. For input/output-only
-        streams, provide None or False as input/output-device.
-
-        The output/output device is merely a dictionary of parameters.
-        Customize those parameters for more precise control over the
-        device.
-
-        If a callback is given, it will be called whenever the stream
-        is active and data is available to read or write. If a
-        finished_callback is given, it will be called whenever the
-        stream is stopped or aborted. If a callback is given, read()
-        and write() should not be used.
-
-        The callback should have a signature like this:
-
-        callback(input, output, time, status) -> flag
-
-        where input is the recorded data as a NumPy array, output is
-        another NumPy array (with uninitialized content), where the data
-        for playback has to be written to (using indexing).
-        Either input or output can be None if the stream was started
-        without input or output device, respectively.
-        time is a dictionary with some timing information, and
-        status indicates whether input or output buffers have
-        been inserted or dropped to overcome underflow or overflow
-        conditions.
-
-        The function must return one of continue_flag, complete_flag or
-        abort_flag.  complete_flag and abort_flag act as if stop() or
-        abort() had been called, respectively.  continue_flag resumes
-        normal audio processing.
-
-        The finished_callback should be a function with no arguments
-        and no return values.
-
-        """
-        if input_device is True:
-            input_device = default_input_device()
-        if output_device is True:
-            output_device = default_output_device()
-
-        if input_device:
-            stream_parameters_in = \
-                ffi.new("PaStreamParameters*",
-                        (input_device['device_index'],
-                         input_device['input_channels'],
-                         _np2pa[input_device['sample_format']],
-                         input_device['input_latency'],
-                         ffi.NULL))
-            self.input_format = np.dtype(input_device['sample_format'])
-            self.input_channels = stream_parameters_in.channelCount
-            if stream_parameters_in and not input_device['interleaved_data']:
-                stream_parameters_in.sampleFormat |= 0x80000000
-        else:
-            stream_parameters_in = ffi.NULL
-            self.input_format = None
-            self.input_channels = 0
-
-        if output_device:
-            stream_parameters_out = \
-                ffi.new("PaStreamParameters*",
-                        (output_device['device_index'],
-                         output_device['output_channels'],
-                         _np2pa[output_device['sample_format']],
-                         output_device['output_latency'],
-                         ffi.NULL))
-            self.output_format = np.dtype(output_device['sample_format'])
-            self.output_channels = stream_parameters_out.channelCount
-            if stream_parameters_out and not output_device['interleaved_data']:
-                stream_parameters_out.sampleFormat |= 0x80000000
-        else:
-            stream_parameters_out = ffi.NULL
-            self.output_format = None
-            self.output_channels = 0
-
-        stream_flags = 0
-        if 'no_clipping' in flags:
+        stream_flags = 0x0
+        if clip_off:
             stream_flags |= 0x00000001
-        if 'no_dithering' in flags:
+        if dither_off:
             stream_flags |= 0x00000002
-        if 'never_drop_input' in flags and flags['never_drop_input']:
+        if never_drop_input:
             stream_flags |= 0x00000004
-        if 'prime_output_buffers_using_callback' in flags:
+        if prime_output_buffers_using_stream_callback:
             stream_flags |= 0x00000008
 
-        if callback:
-            @ffi.callback("PaStreamCallback")
-            def callback_stub(input_ptr, output_ptr, frames, time, status, _):
-                if self.input_channels < 1:
-                    input = None
-                else:
-                    num_bytes = (self.input_channels *
-                                 self.input_format.itemsize * frames)
-                    input = np.frombuffer(ffi.buffer(input_ptr, num_bytes),
-                                          dtype=self.input_format)
-                    input.shape = -1, self.input_channels
-
-                if self.output_channels < 1:
-                    output = None
-                else:
-                    num_bytes = (self.output_channels *
-                                 self.output_format.itemsize * frames)
-                    output = np.frombuffer(ffi.buffer(output_ptr, num_bytes),
-                                           dtype=self.output_format)
-                    output.shape = -1, self.output_channels
-
-                time = {'input_adc_time': time.inputBufferAdcTime,
-                        'current_time': time.currentTime,
-                        'output_dac_time': time.outputBufferDacTime}
-                return callback(input, output, time, status)
-
-            self._callback = callback_stub
+        if callback_wrapper:
+            self._callback = ffi.callback(
+                "PaStreamCallback", callback_wrapper, error=abort_flag)
         else:
             self._callback = ffi.NULL
 
         self._stream = ffi.new("PaStream**")
-        err = _pa.Pa_OpenStream(self._stream, stream_parameters_in or ffi.NULL,
-                                stream_parameters_out or ffi.NULL, samplerate,
-                                blocksize, stream_flags, self._callback,
-                                ffi.NULL)
+        err = _pa.Pa_OpenStream(self._stream, iparameters, oparameters,
+                                samplerate, blocksize, stream_flags,
+                                self._callback, ffi.NULL)
         self._handle_error(err)
 
         # dereference PaStream** --> PaStream*
         self._stream = self._stream[0]
 
         # set some stream information
-        self.samplerate = samplerate
         self.blocksize = blocksize
         info = _pa.Pa_GetStreamInfo(self._stream)
-        if info == ffi.NULL:
+        if not info:
             raise RuntimeError("Could not obtain stream info!")
-        self.input_latency = info.inputLatency
-        self.output_latency = info.outputLatency
+        self.samplerate = info.sampleRate
+        if not oparameters:
+            self.latency = info.inputLatency
+        elif not iparameters:
+            self.latency = info.outputLatency
+        else:
+            self.latency = _unique(info.inputLatency, info.outputLatency)
 
         if finished_callback:
-            @ffi.callback("PaStreamFinishedCallback")
-            def finished_callback_stub(userData):
-                finished_callback()
-            self._finished_callback = finished_callback_stub
+
+            def finished_callback_wrapper(_):
+                return finished_callback()
+
+            self._finished_callback = ffi.callback(
+                "PaStreamFinishedCallback", finished_callback_wrapper)
             err = _pa.Pa_SetStreamFinishedCallback(self._stream,
                                                    self._finished_callback)
             self._handle_error(err)
@@ -561,14 +439,6 @@ class Stream(object):
         """
         return self._handle_error(_pa.Pa_IsStreamStopped(self._stream)) == 1
 
-    def read_length(self):
-        """The number of frames that can be written without waiting."""
-        return _pa.Pa_GetStreamReadAvailable(self._stream)
-
-    def write_length(self):
-        """The number of frames that can be read without waiting."""
-        return _pa.Pa_GetStreamWriteAvailable(self._stream)
-
     def time(self):
         """Returns the current stream time in seconds.
 
@@ -592,6 +462,15 @@ class Stream(object):
         """
         return _pa.Pa_GetStreamCpuLoad(self._stream)
 
+
+class _Reader(object):
+
+    """Mixin for read() and read_length()."""
+
+    def read_length(self):
+        """The number of frames that can be written without waiting."""
+        return _pa.Pa_GetStreamReadAvailable(self._stream)
+
     def read(self, frames, raw=False):
         """Read samples from an input stream.
 
@@ -604,13 +483,23 @@ class Stream(object):
         with one column per channel is returned.
 
         """
-        num_bytes = (self.input_channels * self.input_format.itemsize * frames)
-        data = ffi.new("signed char[]", num_bytes)
+        channels, _ = _split(self.channels)
+        dtype, _ = _split(self.dtype)
+        data = ffi.new("signed char[]", channels * dtype.itemsize * frames)
         self._handle_error(_pa.Pa_ReadStream(self._stream, data, frames))
         if not raw:
-            data = np.frombuffer(ffi.buffer(data), dtype=self.input_format)
-            data.shape = frames, self.input_channels
+            data = np.frombuffer(ffi.buffer(data), dtype=dtype)
+            data.shape = frames, channels
         return data
+
+
+class _Writer(object):
+
+    """Mixin for write() and write_length():"""
+
+    def write_length(self):
+        """The number of frames that can be read without waiting."""
+        return _pa.Pa_GetStreamWriteAvailable(self._stream)
 
     def write(self, data):
         """Write samples to an output stream.
@@ -631,11 +520,11 @@ class Stream(object):
 
         """
         frames = len(data)
-        channels = self.output_channels
+        _, channels = _split(self.channels)
+        _, dtype = _split(self.dtype)
 
-        if (not isinstance(data, np.ndarray) or
-                data.dtype != self.output_format):
-            data = np.array(data, dtype=self.output_format)
+        if (not isinstance(data, np.ndarray) or data.dtype != dtype):
+            data = np.array(data, dtype=dtype)
         if len(data.shape) == 1:
             # broadcast 1D arrays to (n,1) matrices
             data = np.asmatrix(data).T
@@ -647,9 +536,291 @@ class Stream(object):
         if data.shape < (frames, channels):
             # if less data is available than requested, pad with zeros.
             tmp = data
-            data = np.zeros((frames, channels), dtype=self.output_format)
+            data = np.zeros((frames, channels), dtype=dtype)
             data[:tmp.shape[0], :tmp.shape[1]] = tmp
 
         data = data.ravel().tostring()
         err = _pa.Pa_WriteStream(self._stream, data, frames)
         self._handle_error(err)
+
+
+class Stream(_StreamBase, _Reader, _Writer):
+
+    """Streams handle audio input and output to your application.
+
+    Each stream operates at a specific sample rate with specific
+    sample formats and buffer sizes. Each stream can either be half
+    duplex (input only or output only) or full duplex (both input and
+    output). For full duplex operation, the input and output device
+    must use the same audio api.
+
+    Once a stream has been created, audio processing can be started
+    and stopped multiple times using start(), stop() and abort(). The
+    functions is_active() and is_stopped() can be used to check this.
+
+    The functions info(), time() and cpu_load() can be used to get
+    additional information about the stream.
+
+    Data can be read and written to the stream using read() and
+    write(). Use read_length() and write_length() to see how many
+    frames can be read or written at the current time.
+
+    Alternatively, a callback can be specified which is called
+    whenever there is data available to read or write.
+
+    """
+
+    def __init__(self, samplerate=None, blocksize=None,
+                 device=None, channels=None, dtype=None, latency=None,
+                 callback=None, finished_callback=None, **flags):
+        """Open a new stream.
+
+        If no input or output device is specified, the
+        default input/output device is taken.
+
+        If a callback is given, it will be called whenever the stream
+        is active and data is available to read or write. If a
+        finished_callback is given, it will be called whenever the
+        stream is stopped or aborted. If a callback is given, read()
+        and write() should not be used.
+
+        The callback should have a signature like this:
+
+        callback(input, output, time, status) -> flag
+
+        where input is the recorded data as a NumPy array, output is
+        another NumPy array (with uninitialized content), where the data
+        for playback has to be written to (using indexing).
+        time is a dictionary with some timing information, and
+        status indicates whether input or output buffers have
+        been inserted or dropped to overcome underflow or overflow
+        conditions.
+
+        The function must return one of continue_flag, complete_flag or
+        abort_flag.  complete_flag and abort_flag act as if stop() or
+        abort() had been called, respectively.  continue_flag resumes
+        normal audio processing.
+
+        The finished_callback should be a function with no arguments
+        and no return values.
+
+        """
+        idevice, odevice = _split(device)
+        ichannels, ochannels = _split(channels)
+        idtype, odtype = _split(dtype)
+        ilatency, olatency = _split(latency)
+        iparameters, idtype, isamplerate = _get_stream_parameters(
+            'input', idevice, ichannels, idtype, ilatency, samplerate)
+        oparameters, odtype, osamplerate = _get_stream_parameters(
+            'output', odevice, ochannels, odtype, olatency, samplerate)
+        self.dtype = _unique(idtype, odtype)
+        self.device = _unique(iparameters.device, oparameters.device)
+        ichannels = iparameters.channelCount
+        ochannels = oparameters.channelCount
+        self.channels = _unique(ichannels, ochannels)
+        if isamplerate != osamplerate:
+            raise RuntimeError(
+                "Input and output device must have the same samplerate")
+        else:
+            samplerate = isamplerate
+
+        def callback_wrapper(iptr, optr, frames, time, status, _):
+            idata = _frombuffer(iptr, frames, ichannels, idtype)
+            odata = _frombuffer(optr, frames, ochannels, odtype)
+            return callback(idata, odata, _time2dict(time), status)
+
+        _StreamBase.__init__(self, iparameters, oparameters, samplerate,
+                             blocksize, callback and callback_wrapper,
+                             finished_callback, **flags)
+
+
+class InputStream(_StreamBase, _Reader):
+    def __init__(self, samplerate=None, blocksize=None,
+                 device=None, channels=None, dtype=None, latency=None,
+                 callback=None, finished_callback=None, **flags):
+        parameters, self.dtype, samplerate = _get_stream_parameters(
+            'input', device, channels, dtype, latency, samplerate)
+        self.device = parameters.device
+        self.channels = parameters.channelCount
+
+        def callback_wrapper(iptr, optr, frames, time, status, _):
+            data = _frombuffer(iptr, frames, self.channels, self.dtype)
+            return callback(data, _time2dict(time), status)
+
+        _StreamBase.__init__(self, parameters, ffi.NULL, samplerate,
+                             blocksize, callback and callback_wrapper,
+                             finished_callback, **flags)
+
+
+class OutputStream(_StreamBase, _Writer):
+    def __init__(self, samplerate=None, blocksize=None,
+                 device=None, channels=None, dtype=None, latency=None,
+                 callback=None, finished_callback=None, **flags):
+        parameters, self.dtype, samplerate = _get_stream_parameters(
+            'output', device, channels, dtype, latency, samplerate)
+        self.device = parameters.device
+        self.channels = parameters.channelCount
+
+        def callback_wrapper(iptr, optr, frames, time, status, _):
+            data = _frombuffer(optr, frames, self.channels, self.dtype)
+            return callback(data, _time2dict(time), status)
+
+        _StreamBase.__init__(self, ffi.NULL, parameters, samplerate,
+                             blocksize, callback and callback_wrapper,
+                             finished_callback, **flags)
+
+
+def _get_stream_parameters(kind, device, channels, dtype, latency, samplerate):
+    """Generate PaStreamParameters struct."""
+    if device is None:
+        device = default[kind].device
+    if channels is None:
+        channels = default[kind].channels
+    if dtype is None:
+        dtype = default[kind].dtype
+    if latency is None:
+        latency = default[kind].latency
+    if samplerate is None:
+        samplerate = default.samplerate
+
+    info = device_info(device)
+    if channels is None:
+        channels = info['max_' + kind + '_channels']
+    dtype = np.dtype(dtype)
+    try:
+        sample_format = _np2pa[dtype]
+    except KeyError:
+        raise ValueError("Invalid " + kind + " sample format")
+    if samplerate is None:
+        samplerate = info['default_samplerate']
+    parameters = ffi.new(
+        "PaStreamParameters*",
+        (device, channels, sample_format, latency, ffi.NULL))
+    return parameters, dtype, samplerate
+
+
+def _frombuffer(ptr, frames, channels, dtype):
+    """Create NumPy array from a pointer to some memory."""
+    framesize = channels * dtype.itemsize
+    data = np.frombuffer(ffi.buffer(ptr, frames * framesize), dtype=dtype)
+    data.shape = -1, channels
+    return data
+
+
+def _time2dict(time):
+    """Convert PaStreamCallbackTimeInfo struct to dict."""
+    return {'input_adc_time':  time.inputBufferAdcTime,
+            'current_time':    time.currentTime,
+            'output_dac_time': time.outputBufferDacTime}
+
+
+def _split(value):
+    """Split input/output value into two values."""
+    if isinstance(value, str):
+        # str is iterable, which would interfere with tuple unpacking
+        return value, value
+    try:
+        invalue, outvalue = value
+    except (TypeError, ValueError):
+        invalue = outvalue = value
+    return invalue, outvalue
+
+
+def _unique(ivalue, ovalue):
+    """Return a single value if values are the same, a tuple if not."""
+    return ivalue if ivalue == ovalue else (ivalue, ovalue)
+
+
+class _InputOutputDescriptor(object):
+    def __init__(self, gettername, settername=None):
+        self.gettername = gettername
+        self.settername = gettername if settername is None else settername
+
+    def __get__(self, obj, objclass):
+        invalue, outvalue = _split(getattr(obj._defaults, self.gettername))
+        return invalue if obj._isinput else outvalue
+
+    def __set__(self, obj, value):
+        invalue, outvalue = _split(getattr(obj._defaults, self.settername))
+        if obj._isinput and value != outvalue:
+            value = value, outvalue
+        elif not obj._isinput and value != invalue:
+            value = invalue, value
+        setattr(obj._defaults, self.settername, value)
+
+
+class _InputOutputDefaults(object):
+    def __init__(self, isinput, defaults):
+        self._isinput = isinput
+        self._defaults = defaults
+
+    device = _InputOutputDescriptor('device', '_device')
+    channels = _InputOutputDescriptor('channels')
+    dtype = _InputOutputDescriptor('dtype')
+    latency = _InputOutputDescriptor('latency')
+
+
+class _Defaults(object):
+
+    """Override default values for pysoundcard module.
+
+    :attr:`default` is the only instance of this class.
+
+    """
+
+    _device = None
+
+    channels = None
+    dtype = 'float32'
+    latency = 0
+
+    samplerate = None
+    blocksize = 0
+    clip_off = False
+    dither_off = False
+    never_drop_input = False
+    prime_output_buffers_using_stream_callback = False
+
+    def __setattr__(self, name, value):
+        """Only allow setting existing attributes."""
+        if name in dir(self):
+            object.__setattr__(self, name, value)
+        else:
+            raise AttributeError(
+                "'default' object has no attribute %s" % repr(name))
+
+    def __getitem__(self, kind):
+        if kind in ('in', 'input'):
+            isinput = True
+        elif kind in ('out', 'output'):
+            isinput = False
+        else:
+            raise KeyError(kind)
+        return _InputOutputDefaults(isinput, self)
+
+    @property
+    def device(self):
+        invalue, outvalue = _split(self._device)
+        if any([invalue is None, outvalue is None]):
+            if invalue is None:
+                invalue = _pa.Pa_GetDefaultInputDevice()
+            if outvalue is None:
+                outvalue = _pa.Pa_GetDefaultOutputDevice()
+            return _unique(invalue, outvalue)
+        else:
+            return self._device
+
+    @device.setter
+    def device(self, value):
+        self._device = value
+
+    @property
+    def hostapi(self):
+        return _pa.Pa_GetDefaultHostApi()
+
+    def reset(self):
+        """Reset all attributes to their "factory default"."""
+        self.__dict__ = {}
+
+default = _Defaults()
+"""Module defaults."""

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -451,8 +451,8 @@ class Stream(object):
         info = _pa.Pa_GetStreamInfo(self._stream)
         if info == ffi.NULL:
             raise RuntimeError("Could not obtain stream info!")
-        self.input_latency = info.inputLatency,
-        self.output_latency = info.outputLatency,
+        self.input_latency = info.inputLatency
+        self.output_latency = info.outputLatency
 
         if finished_callback:
             @ffi.callback("PaStreamFinishedCallback")

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -245,7 +245,7 @@ def _dev2dict(dev, index):
             'default_low_output_latency': dev.defaultLowOutputLatency,
             'default_high_input_latency': dev.defaultHighInputLatency,
             'default_high_output_latency': dev.defaultHighOutputLatency,
-            'default_sample_rate': dev.defaultSampleRate,
+            'default_samplerate': dev.defaultSampleRate,
             'input_latency': dev.defaultLowInputLatency,
             'output_latency': dev.defaultLowOutputLatency,
             'sample_format': np.float32,
@@ -313,7 +313,7 @@ class Stream(object):
 
     """
 
-    def __init__(self, sample_rate=44100, block_length=0,
+    def __init__(self, samplerate=44100, blocksize=0,
                  input_device=True, output_device=True,
                  callback=None, finished_callback=None,
                  **flags):
@@ -439,8 +439,8 @@ class Stream(object):
 
         self._stream = ffi.new("PaStream**")
         err = _pa.Pa_OpenStream(self._stream, stream_parameters_in or ffi.NULL,
-                                stream_parameters_out or ffi.NULL, sample_rate,
-                                block_length, stream_flags, self._callback,
+                                stream_parameters_out or ffi.NULL, samplerate,
+                                blocksize, stream_flags, self._callback,
                                 ffi.NULL)
         self._handle_error(err)
 
@@ -448,8 +448,8 @@ class Stream(object):
         self._stream = self._stream[0]
 
         # set some stream information
-        self.sample_rate = sample_rate
-        self.block_length = block_length
+        self.samplerate = samplerate
+        self.blocksize = blocksize
         info = _pa.Pa_GetStreamInfo(self._stream)
         if info == ffi.NULL:
             raise RuntimeError("Could not obtain stream info!")
@@ -618,9 +618,9 @@ class Stream(object):
     def write(self, data):
         """Write samples to an output stream.
 
-        As much as one block_length of audio data will be played
-        without blocking. If more than one block_length was provided,
-        the function will only return when all but one block_length
+        As much as one blocksize of audio data will be played
+        without blocking. If more than one blocksize was provided,
+        the function will only return when all but one blocksize
         has been played.
 
         Data will be converted to a numpy matrix. Multichannel data
@@ -665,17 +665,17 @@ if __name__ == '__main__':
     fs, wave = wavread('thistle.wav')
     wave = np.array(wave, dtype=np.float32)
     wave /= 2**15
-    block_length = 4
+    blocksize = 4
 
     def callback(in_data, frame_count, time_info, status):
         if status != 0:
             print(status)
         return (in_data, continue_flag)
-    s = Stream(sample_rate=fs, block_length=block_length, callback=callback)
+    s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
     s.start()
-    # for n in range(int(fs*5/block_length)):
-    #     s.write(s.read(block_length))
-    # for idx in range(0, wave.size, block_length):
-    #     s.write(wave[idx:idx+block_length])
+    # for n in range(int(fs*5/blocksize)):
+    #     s.write(s.read(blocksize))
+    # for idx in range(0, wave.size, blocksize):
+    #     s.write(wave[idx:idx+blocksize])
     time.sleep(5)
     s.stop()

--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -655,25 +655,3 @@ class Stream(object):
         data = data.ravel().tostring()
         err = _pa.Pa_WriteStream(self._stream, data, frames)
         self._handle_error(err)
-
-
-if __name__ == '__main__':
-    from scipy.io.wavfile import read as wavread
-    import time
-    fs, wave = wavread('thistle.wav')
-    wave = np.array(wave, dtype=np.float32)
-    wave /= 2**15
-    blocksize = 4
-
-    def callback(in_data, frame_count, time_info, status):
-        if status != 0:
-            print(status)
-        return (in_data, continue_flag)
-    s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
-    s.start()
-    # for n in range(int(fs*5/blocksize)):
-    #     s.write(s.read(blocksize))
-    # for idx in range(0, wave.size, blocksize):
-    #     s.write(wave[idx:idx+blocksize])
-    time.sleep(5)
-    s.stop()

--- a/tests/context_manager.py
+++ b/tests/context_manager.py
@@ -7,5 +7,5 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-with Stream(sample_rate=44100, block_length=16, callback=callback):
+with Stream(samplerate=44100, blocksize=16, callback=callback):
     time.sleep(5)

--- a/tests/loopback_blocking.py
+++ b/tests/loopback_blocking.py
@@ -3,9 +3,9 @@ from pysoundcard import Stream
 """Loop back five seconds of audio data."""
 
 fs = 44100
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
-for n in range(int(fs * 5 / block_length)):
-    s.write(s.read(block_length))
+for n in range(int(fs * 5 / blocksize)):
+    s.write(s.read(blocksize))
 s.stop()

--- a/tests/loopback_callback.py
+++ b/tests/loopback_callback.py
@@ -7,7 +7,7 @@ def callback(in_data, out_data, time_info, status):
     out_data[:] = in_data
     return continue_flag
 
-s = Stream(sample_rate=44100, block_length=16, callback=callback)
+s = Stream(samplerate=44100, blocksize=16, callback=callback)
 s.start()
 time.sleep(5)
 s.stop()

--- a/tests/playback_blocking.py
+++ b/tests/playback_blocking.py
@@ -9,8 +9,8 @@ fs, wave = wavread(sys.argv[1])
 wave = np.array(wave, dtype=np.float32)
 wave /= 2 ** 15  # normalize -max_int16..max_int16 to -1..1
 
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize)
 s.start()
 s.write(wave)
 s.stop()

--- a/tests/playback_callback.py
+++ b/tests/playback_callback.py
@@ -11,18 +11,8 @@ wave = np.array(wave, dtype=np.float32)
 wave /= 2 ** 15  # normalize -max_int16..max_int16 to -1..1
 play_position = 0
 
-def callback(in_data, out_data, time_info, status):
-    global play_position
-    out_data[:] = wave[play_position:play_position + block_length]
-    # TODO: handle last (often incomplete) block
-    play_position += block_length
-    if play_position + block_length < len(wave):
-        return continue_flag
-    else:
-        return complete_flag
-
-block_length = 16
-s = Stream(sample_rate=fs, block_length=block_length, callback=callback)
+blocksize = 16
+s = Stream(samplerate=fs, blocksize=blocksize, callback=callback)
 s.start()
 while s.is_active():
     time.sleep(0.1)


### PR DESCRIPTION
This is an alternative to #39.
It includes most of the changes discussed there.

The main difference is that there are not 3 kinds of arguments (e.g. `device`, `input_device` and `output_device`) anymore.
Instead, there is only one kind of argument (e.g. `device`) which can optionally hold a pair of values (first for "input", second for "output").

The attributes of the `default` object can also optionally hold pairs of values, eg. `pa.default.channels = 2, 1`.
The most common case, however, will be to assign single values which are used for both input and output.
To get/set single values for only one of input/output, `pa.default["input"].channels` and `pa.default["output"].channels` can be used, respectively.

Also, as discussed in #39, the functions `default_input_device()` and `default_output_device()` are incorporated into `pa.default.device`.