### PR TITLE
Update pysoundcard.py

### DIFF
--- a/pysoundcard.py
+++ b/pysoundcard.py
@@ -109,6 +109,24 @@ const char *Pa_GetVersionText(void);
 
 typedef int PaDeviceIndex;
 
+typedef enum PaHostApiTypeId
+{
+    paInDevelopment=0, /* use while developing support for a new host API */
+    paDirectSound=1,
+    paMME=2,
+    paASIO=3,
+    paSoundManager=4,
+    paCoreAudio=5,
+    paOSS=7,
+    paALSA=8,
+    paAL=9,
+    paBeOS=10,
+    paWDMKS=11,
+    paJACK=12,
+    paWASAPI=13,
+    paAudioScienceHPI=14
+} PaHostApiTypeId;
+
 typedef struct PaHostApiInfo {
     int structVersion;
     enum PaHostApiTypeId type;


### PR DESCRIPTION
Add typedef for typedef enum PaHostApiTypeId, it was triggering an error in CFFI (will be revert to a warning after CFFI 1.8)

https://bitbucket.org/cffi/cffi/issues/234/cffi-131-userwarning-about